### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.git/
+.gitignore


### PR DESCRIPTION
Essential for ignoring files while building images like .gitignore
While building Images docker sends all the files to the Docker daemon for the build process this helps to reduce build time